### PR TITLE
Fixed deprecation warning related to Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 exports.atob = function atob(val) {
-  return new Buffer(val, 'base64').toString();
+  return new Buffer.from(val, 'base64').toString();
 };
 
 exports.btoa = function btoa(val) {
-  return new Buffer(val).toString('base64');
+  return Buffer.from(val).toString('base64');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-base64",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "atob and btoa for browsers or node",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
```(node:9547) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.```